### PR TITLE
corrected typo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 First go to the parent directory and run the following commands to install all the pre-requisites.
 
-  ```pip3 install -r requirements```
+  ```pip3 install -r requirements.txt```
   
 Then, edit the 'demats.txt' file and add all the accounts' information each account separated by a line break and each information separated by commas ','
 


### PR DESCRIPTION
changed pip3 install -r requirements to pip3 install -r requirements.txt because without txt extension it throw error in terminal that file or directory not found.